### PR TITLE
Add a production build option

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "src/react-patch.js",
   "scripts": {
     "start": "./node_modules/.bin/webpack && node server.js",
-    "build": "./node_modules/.bin/webpack"
+    "build": "./node_modules/.bin/webpack",
+    "build:min": "cross-env NODE_ENV=production ./node_modules/.bin/webpack"
   },
   "author": "Matt Hartman",
   "contributors": [
@@ -16,9 +17,10 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "react": "15.3.1",
-    "webpack": "1.13.2",
+    "cross-env": "^3.1.4",
     "express": "4.14.0",
-    "react-tap-event-plugin": "^1.0.0"
+    "react": "15.3.1",
+    "react-tap-event-plugin": "^1.0.0",
+    "webpack": "1.13.2"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,8 @@
 var webpack = require('webpack');
 
-module.exports = {
+var env = process.env.NODE_ENV;
+
+var config = {
   entry: {
     React: ['./src/react-patch.js'],
   },
@@ -11,5 +13,21 @@ module.exports = {
     filename: 'react-with-addons.js',
   },
   devtools: 'eval',
-  plugins: [],
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify(env)
+    })
+  ],
 };
+
+if (env === 'production') {
+  config.plugins.push(
+    new webpack.optimize.UglifyJsPlugin({
+      compress:{
+        warnings: false 
+      }
+    })
+  );
+}
+
+module.exports = config;


### PR DESCRIPTION
This PR adds an option to run `npm run build:min` to create a minified production build of React. It also uses the cross-env library to ensure consistent environment behavior across platforms.